### PR TITLE
Setup deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,27 @@
+# Use the official lightweight Python 3.10 image
 FROM python:3.10-slim
 
-RUN apt-get update && apt-get install -y \
-    g++ \
-    ffmpeg \
-    libgl1 \
-    libglib2.0-0 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install system dependencies including ffmpeg
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
 
+# Set the working directory inside the container
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+# Copy the current directory contents into the container at /app
+COPY . /app
 
-RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords'); nltk.download('averaged_perceptron_tagger')"
+# Upgrade pip and install Python dependencies
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
 
-COPY . .
+# Download necessary NLTK data packages
+RUN python -c "import nltk; [nltk.download(pkg) for pkg in ['punkt','stopwords','averaged_perceptron_tagger']]"
 
-RUN python sentimental_analysis/manage.py makemigrations
-RUN python sentimental_analysis/manage.py migrate
-
-
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV DJANGO_ALLOWED_HOSTS=0.0.0.0,localhost
-
+# Expose port 8000 for the Django development server
 EXPOSE 8000
 
-CMD ["python", "sentimental_analysis/manage.py", "runserver", "0.0.0.0:8000"]
+# Run Django migrations and then start the Django development server.
+# Note: Adjust the manage.py path if necessary.
+CMD ["bash", "-c", "python sentimental_analysis/manage.py makemigrations && python sentimental_analysis/manage.py migrate && python sentimental_analysis/manage.py runserver 0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # Use the official lightweight Python 3.10 image
 FROM python:3.10-slim
 
-# Install system dependencies including ffmpeg
+# Install system dependencies including ffmpeg and build tools (g++ is part of build-essential)
 RUN apt-get update && \
-    apt-get install -y ffmpeg && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory inside the container

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+up:
+	docker compose up --build --remove-orphans -d
+
+down:
+	docker compose down --remove-orphans
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - DJANGO_ALLOWED_HOSTS=0.0.0.0,localhost,127.0.0.1


### PR DESCRIPTION
This pull request includes several changes to the Docker setup and the addition of new commands to the `Makefile`. The most important changes include updates to the `Dockerfile`, the addition of a `docker-compose.yaml` file, and new targets in the `Makefile` for managing Docker containers.

Improvements to Docker setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R29): Updated to use the official lightweight Python 3.10 image, install system dependencies including ffmpeg and build tools, upgrade pip, and install Python dependencies. Also added commands to run Django migrations and start the Django development server.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R1-R7): Added a new `docker-compose.yaml` file to define the `web` service, which builds the Docker image, maps port 8000, and sets environment variables for Django allowed hosts.

New Makefile commands:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R6): Added `up` and `down` targets to start and stop Docker containers using Docker Compose.